### PR TITLE
Reuse a single connection to the BoM

### DIFF
--- a/bom_exporter.py
+++ b/bom_exporter.py
@@ -33,6 +33,8 @@ WIND_DIR_TO_DEGREES = {dir: fraction*360 for dir,
                        fraction in WIND_DIR_TO_TURN_FRACTIONS.items()}
 
 
+session = requests.Session()
+
 class BOMCollector:
     def collect(self):
         bom_utctimestamp = GaugeMetricFamily(
@@ -78,7 +80,7 @@ class BOMCollector:
         )
 
         for url in urls:
-            data = requests.get(url).json()
+            data = session.get(url).json()
 
             latest_obs = data["observations"]["data"][0]
 


### PR DESCRIPTION
Should reduce query latency because we already
have a connection ready to go.

I thought python-requests might automatically do this for us, but
https://github.com/kennethreitz/requests/issues/3445#issuecomment-263820399
says you need a Session, as does my debugging.

Before, with logging at level DEBUG
Starting new HTTP connection (1): www.bom.gov.au:80
http://www.bom.gov.au:80 "GET /fwo/IDN60801/IDN60801.94767.json HTTP/1.1" 200 7930
Starting new HTTP connection (1): www.bom.gov.au:80
http://www.bom.gov.au:80 "GET /fwo/IDN60901/IDN60901.94768.json HTTP/1.1" 200 6719

After:
Starting new HTTP connection (1): www.bom.gov.au:80
http://www.bom.gov.au:80 "GET /fwo/IDN60801/IDN60801.94767.json HTTP/1.1" 200 7919
http://www.bom.gov.au:80 "GET /fwo/IDN60901/IDN60901.94768.json HTTP/1.1" 200 6719