### PR TITLE
Switch to balenalib so we can compile ARM Docker images from x86_64 machines

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.formatting.provider": "black"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# This can compile fine on my Mac x86_64 machine. Maybe Docker's virtualizing it?
+
 FROM arm32v6/alpine
 
 RUN apk update && apk add python3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# This can compile fine on my Mac x86_64 machine. Maybe Docker's virtualizing it?
+# This can compile fine on my Mac x86_64 machine, and on Cloud Build thanks to cross-build-start.
 
 FROM balenalib/raspberrypi3-python:3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 # This can compile fine on my Mac x86_64 machine. Maybe Docker's virtualizing it?
 
-FROM arm32v6/alpine
+FROM balenalib/raspberrypi3-python:3
 
-RUN apk update && apk add python3
-RUN python3 -m ensurepip && \
-    rm -r /usr/lib/python*/ensurepip
-RUN python3 -m pip install prometheus_client requests
+# https://www.balena.io/docs/reference/base-images/base-images/#building-arm-containers-on-x86-machines
+RUN [ "cross-build-start" ]
+
+# RUN apt-get update && apt-get install python3-pip
+RUN python -m pip install prometheus_client requests
+
+# https://www.balena.io/docs/reference/base-images/base-images/#building-arm-containers-on-x86-machines
+RUN [ "cross-build-end" ]
+
 COPY bom_exporter.py /root
 EXPOSE 8000
 ENTRYPOINT ["python3", "/root/bom_exporter.py"]

--- a/README.md
+++ b/README.md
@@ -15,9 +15,13 @@ Example `docker-compose.yml` config:
 ```yml
 version: '3.4'
 services:
-  rtl_433_prometheus:
-    image: markhnsn/rtl_433_prometheus
+  bom_exporter:
+    image: vickilowe/bom_exporter
     restart: always
+    command: [
+      "--urls",
+      "http://www.bom.gov.au/fwo/IDN60801/IDN60801.94767.json",
+    ]
     ports:
     - "8000:8000"
 ```
@@ -27,6 +31,6 @@ Example `prometheus.yml`:
 ```yml
 scrape_configs:
   - job_name: 'bom_exporter'
-      static_configs:
-            - targets: ['hostname:8000']
+    static_configs:
+      - targets: ['hostname:8000']
 ```

--- a/README.md
+++ b/README.md
@@ -9,3 +9,24 @@ docker run -p 8000:8000 bom_exporter:latest
 
 # To get just the docker image
 Visit the docker image [here](https://hub.docker.com/r/vickilowe/bom_exporter)
+
+Example `docker-compose.yml` config:
+
+```yml
+version: '3.4'
+services:
+  rtl_433_prometheus:
+    image: markhnsn/rtl_433_prometheus
+    restart: always
+    ports:
+    - "8000:8000"
+```
+
+Example `prometheus.yml`:
+
+```yml
+scrape_configs:
+  - job_name: 'bom_exporter'
+      static_configs:
+            - targets: ['hostname:8000']
+```

--- a/bom_exporter.py
+++ b/bom_exporter.py
@@ -96,7 +96,8 @@ class BOMCollector:
             bom_pressure_pascals.add_metric(
                 labels, latest_obs["press"]*100)  # hPa to Pa
             bom_relative_humidity.add_metric(labels, latest_obs["rel_hum"])
-            bom_wind_speed.add_metric(labels, latest_obs["wind_spd_kmh"])
+            if latest_obs["wind_spd_kmh"] != None:
+                bom_wind_speed.add_metric(labels, latest_obs["wind_spd_kmh"])
             bom_apparent_temperature_celsius.add_metric(
                 labels, latest_obs["apparent_t"])
 

--- a/bom_exporter.py
+++ b/bom_exporter.py
@@ -1,14 +1,15 @@
 from datetime import datetime, timezone
 import time
 import requests
+import argparse
 
 from prometheus_client import start_http_server
 from prometheus_client.core import GaugeMetricFamily, REGISTRY
 
-urls = [
-    "http://www.bom.gov.au/fwo/IDN60801/IDN60801.94767.json",
-    "http://www.bom.gov.au/fwo/IDN60901/IDN60901.94768.json",
-]
+parser = argparse.ArgumentParser(description='Bureau of Meteorology Prometheus Exporter')
+parser.add_argument('--urls', nargs='+', type=str,
+                    help='One or more BoM Observation JSON URLs, e.g. http://www.bom.gov.au/fwo/IDN60801/IDN60801.94765.json')
+args = parser.parse_args()
 
 WIND_DIR_TO_TURN_FRACTIONS = {
     "N":    0/16,
@@ -79,7 +80,7 @@ class BOMCollector:
             labels=["location"],
         )
 
-        for url in urls:
+        for url in args.urls:
             data = session.get(url).json()
 
             latest_obs = data["observations"]["data"][0]

--- a/bom_exporter.py
+++ b/bom_exporter.py
@@ -93,14 +93,18 @@ class BOMCollector:
 
             labels = [latest_obs["name"]]
             bom_utctimestamp.add_metric(labels, unix_epoch)
-            bom_air_temperature.add_metric(labels, latest_obs["air_temp"])
-            bom_pressure_pascals.add_metric(
-                labels, latest_obs["press"]*100)  # hPa to Pa
-            bom_relative_humidity.add_metric(labels, latest_obs["rel_hum"])
+            if latest_obs["air_temp"] != None:
+                bom_air_temperature.add_metric(labels, latest_obs["air_temp"])
+            if latest_obs["press"] != None:
+                bom_pressure_pascals.add_metric(
+                    labels, latest_obs["press"]*100)  # hPa to Pa
+            if latest_obs["rel_hum"] != None:
+                bom_relative_humidity.add_metric(labels, latest_obs["rel_hum"])
             if latest_obs["wind_spd_kmh"] != None:
                 bom_wind_speed.add_metric(labels, latest_obs["wind_spd_kmh"])
-            bom_apparent_temperature_celsius.add_metric(
-                labels, latest_obs["apparent_t"])
+            if latest_obs["apparent_t"] != None:
+                bom_apparent_temperature_celsius.add_metric(
+                    labels, latest_obs["apparent_t"])
 
             wind_dir = latest_obs["wind_dir"]
             if wind_dir in WIND_DIR_TO_DEGREES:


### PR DESCRIPTION
Balenalib has magic cross-compilation commands, which let us build the docker image on our 64bit macOS and run it on 32bit ARM machines.